### PR TITLE
Add TRMNL first-party acquisition notice to README and index page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # TRMNL Plugins
 
-**This plugin has been acquired by TRMNL and is now a first-party plugin.** Check it out at [trmnl.com/integrations/apple-photos](https://trmnl.com/integrations/apple-photos).
+This plugin has been acquired by TRMNL and is now a [first-party plugin](https://trmnl.com/integrations/apple-photos).
 
 This repository contains the sources for the [Apple Photos plugins](https://trmnl.com/plugin_settings/new?keyname=apple_photos) and (not yet released) Google Photos plugins.
+
+If you like the plugins, [please consider making a donation](https://buy.polar.sh/polar_cl_G5yA5blwytLyunu2gWo9SETvWQ6p0xceUbWqz02o2dK) to help fund it's hosting costs. 🧡

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # TRMNL Plugins
 
-This repository contains the sources for the [Apple Photos plugins](https://trmnl.com/plugin_settings/new?keyname=apple_photos) and (not yet released) Google Photos plugins.
+**This plugin has been acquired by TRMNL and is now a first-party plugin.** Check it out at [trmnl.com/integrations/apple-photos](https://trmnl.com/integrations/apple-photos).
 
-If you like the plugins, [please consider making a donation](https://buy.polar.sh/polar_cl_G5yA5blwytLyunu2gWo9SETvWQ6p0xceUbWqz02o2dK) to help fund it's hosting costs. 🧡
+This repository contains the sources for the [Apple Photos plugins](https://trmnl.com/plugin_settings/new?keyname=apple_photos) and (not yet released) Google Photos plugins.

--- a/src/app/(web)/apple/page.tsx
+++ b/src/app/(web)/apple/page.tsx
@@ -11,13 +11,12 @@ export default function Home() {
   return (
     <div className="flex flex-col gap-4">
       <p className="font-bold">
-        This plugin has been acquired by TRMNL and is now a first-party plugin.
-        Check it out at{' '}
+        This plugin has been acquired by TRMNL and is now a{' '}
         <a
           className="text-blue-500"
           href="https://trmnl.com/integrations/apple-photos"
         >
-          trmnl.com/integrations/apple-photos
+          first-party plugin
         </a>
         .
       </p>

--- a/src/app/(web)/apple/page.tsx
+++ b/src/app/(web)/apple/page.tsx
@@ -10,6 +10,18 @@ export const metadata: Metadata = {
 export default function Home() {
   return (
     <div className="flex flex-col gap-4">
+      <p className="font-bold">
+        This plugin has been acquired by TRMNL and is now a first-party plugin.
+        Check it out at{' '}
+        <a
+          className="text-blue-500"
+          href="https://trmnl.com/integrations/apple-photos"
+        >
+          trmnl.com/integrations/apple-photos
+        </a>
+        .
+      </p>
+
       <p>
         Hey! This is a plugin for TRMNL, that displays a random photo from a
         Apple Photos album.
@@ -31,17 +43,6 @@ export default function Home() {
           the TRMNL plugin page
         </a>
         .
-      </p>
-
-      <p>
-        No bugs?{' '}
-        <a
-          className="text-blue-500"
-          href="https://buy.polar.sh/polar_cl_I7pc5Mh2nCfQk3cyLow5mxm6qg0ncpb3Ru8bu0qRKzy"
-        >
-          Donate
-        </a>{' '}
-        to support it's development. ❤️
       </p>
 
       <p>


### PR DESCRIPTION
This plugin has been acquired by TRMNL and is now a first-party plugin.
Added notice with link to https://trmnl.com/integrations/apple-photos
and removed the donation link from the index page.

https://claude.ai/code/session_01GStfLxEZHCz2ix1MvLbjwi